### PR TITLE
Adding webplayer to site

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,6 +18,7 @@
   <ul>
   <li><a href="./index.html">home</a></li>
   <li><a href="./news.html">news</a></li>
+  <li><a href="./play.html">play</a></li>
   <li><a href="./projects.html">projects</a></li>
   <li><a href="./download.html">download</a></li>
   <li><a href="./documentation.html">documentation</a></li>

--- a/download.html
+++ b/download.html
@@ -18,6 +18,7 @@
   <ul>
   <li><a href="./index.html">home</a></li>
   <li><a href="./news.html">news</a></li>
+  <li><a href="./play.html">play</a></li>
   <li><a href="./projects.html">projects</a></li>
   <li><a href="./download.html">download</a></li>
   <li><a href="./documentation.html">documentation</a></li>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <ul>
   <li><a href="./index.html">home</a></li>
   <li><a href="./news.html">news</a></li>
+  <li><a href="./play.html">play</a></li>
   <li><a href="./projects.html">projects</a></li>
   <li><a href="./download.html">download</a></li>
   <li><a href="./documentation.html">documentation</a></li>

--- a/news.html
+++ b/news.html
@@ -18,6 +18,7 @@
   <ul>
   <li><a href="./index.html">home</a></li>
   <li><a href="./news.html">news</a></li>
+  <li><a href="./play.html">play</a></li>
   <li><a href="./projects.html">projects</a></li>
   <li><a href="./download.html">download</a></li>
   <li><a href="./documentation.html">documentation</a></li>

--- a/play.html
+++ b/play.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+  <meta charset="UTF-8">
+
+  <title>EDGE-Classic: Main</title>
+  <link rel="stylesheet" type="text/css" href="css/slider.css">
+
+</head>
+
+<body>
+
+  <IMG SRC="logo.png" HEIGHT="110" BORDER=0 ALT="">
+
+  <nav class="navMenu">
+    <ul>
+      <li><a href="./index.html">home</a></li>
+      <li><a href="./news.html">news</a></li>
+      <li><a href="./play.html">play</a></li>
+      <li><a href="./projects.html">projects</a></li>
+      <li><a href="./download.html">download</a></li>
+      <li><a href="./documentation.html">documentation</a></li>
+      <li><a href="https://github.com/edge-classic/EDGE-classic/">github repo</a></li>
+      <li><a href="./about.html">about</a></li>
+      <li><a href="https://discord.gg/jUhEKHGWZm">discord</a></li>
+    </ul>
+  </nav>
+
+  <br>
+  <br>
+  <br>
+
+  <div style="padding-left: 300px;">
+    <iframe style="border-width: 0px;" allowfullscreen="yes" scrolling="no" width=1280px height=720px src="https://pbdot.github.io/edge-classic-site-webplayer"></iframe>
+  </div>
+
+
+</body>
+
+</html>

--- a/projects.html
+++ b/projects.html
@@ -18,6 +18,7 @@
   <ul>
   <li><a href="./index.html">home</a></li>
   <li><a href="./news.html">news</a></li>
+  <li><a href="./play.html">play</a></li>
   <li><a href="./projects.html">projects</a></li>
   <li><a href="./download.html">download</a></li>
   <li><a href="./documentation.html">documentation</a></li>


### PR DESCRIPTION
This adds the play page to the web site with web player embedded in an iframe.  I setup pbdot.github.io to use submodules, so can host multiple websites and not bloat the GitHub Pages repo.  If we want to host the player in an edge-classic organization repo, instead of "pbdot.github.io/edge-classic-site-webplayer" for the iframe, that should be doable. 